### PR TITLE
[tox] Fix spelling of minversion, fix ansible-lint failures

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,6 @@
 skip_list:  # or 'skip_list' to silence them completely
   - unnamed-task  # All tasks should be named
+
+exclude_paths:
+  - .cache
+  - .github

--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -1,4 +1,4 @@
-.. _canonical.maas.{{ module }}_module:
+.. _maas.maas.{{ module }}_module:
 
 {% set title = module + ' -- ' + short_description | rst_ify %}
 {{ title }}

--- a/examples/get_tags.yml
+++ b/examples/get_tags.yml
@@ -9,7 +9,7 @@
           token_key: kDcKvtWX7fXLB7TvB2
           token_secret: ktBqeLMRvLBDLFm7g8xybgpQ4jSkkwgk
           customer_key: tqDErtYzyzRVdUb9hS
-      register: tags
+      register: maas_tags
 
     - ansible.builtin.debug:
-        var: tags
+        var: maas_tags

--- a/plugins/modules/vm_host_machine.py
+++ b/plugins/modules/vm_host_machine.py
@@ -56,6 +56,7 @@ options:
   storage_disks:
     description:
       - Storage disks.
+    default: []
     type: list
     elements: dict
     suboptions:

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,8 @@
 [base]
-lint_paths =
-    plugins/ \
-    tests/unit/
+lint_paths = plugins/ tests/unit/
 
 [tox]
-min_version = 4
+minversion = 4
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ commands =
 passenv =
   HOME
 deps =
-    ansible-lint==6.16.0
+    ansible-lint==6.17.2
     black
     flake8
     flake8-pyproject


### PR DESCRIPTION
tox.ini wants `minversion` not `min_version` - this caused older toxen to fail to self-ugprade

Drive-by fixes to ansible-lint to appease the CI gods

## Checklist before merging
- [:heavy_check_mark: ] Formatting: `tox -e format`
- [:heavy_check_mark:] Linting: `tox -e sanity`
- [:heavy_check_mark:] Unit tests: `tox -e units`
