### PR TITLE
ci: autoclose stale issues

### DIFF
--- a/.github/workflows/inactiveissue.yml
+++ b/.github/workflows/inactiveissue.yml
@@ -1,0 +1,27 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 30
+          exempt-issue-labels: "triaged, help wanted"
+          stale-issue-label: "stale"
+          stale-issue-message:
+            "This issue is stale because it has been open for 30 days with no
+            activity."
+          close-issue-message:
+            "This issue was closed because it has been inactive for 30 days
+            since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Mark issue as stale if there is no activity for 30 days. Close stale issues after 30 days. 
This doesn't affect issues with labels: `triaged` or `help wanted`