### PR TITLE
Move to canonical org

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -41,16 +41,16 @@ tags:
 dependencies: {}
 
 # The URL of the originating SCM repository
-repository: https://github.com/maas/ansible-collection
+repository: https://github.com/canonical/ansible-collection
 
 # The URL to any online docs
-documentation: https://github.com/maas/ansible-collection
+documentation: https://github.com/canonical/ansible-collection
 
 # The URL to the homepage of the collection/project
 homepage: https://maas.io
 
 # The URL to the collection issue tracker
-issues: https://github.com/maas/ansible-collection/issues
+issues: https://github.com/canonical/ansible-collection/issues
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -128,9 +128,9 @@ class Client:
         headers = dict(headers or DEFAULT_HEADERS, **self.auth_header)
         if data is not None:
             boundary, data = Multipart.get_mulipart(data)
-            headers[
-                "Content-type"
-            ] = f'multipart/form-data; boundary="{boundary}"'
+            headers["Content-type"] = (
+                f'multipart/form-data; boundary="{boundary}"'
+            )
         elif binary_data is not None:
             data = binary_data
 

--- a/plugins/module_utils/machine.py
+++ b/plugins/module_utils/machine.py
@@ -282,9 +282,9 @@ class Machine(MaasValueMapper):
                     payload_string_list.append(f"vlan={net_interface['vlan']}")
                 if net_interface.get("name"):
                     payload_string_list.append(f"name={net_interface['name']}")
-                payload[
-                    "interfaces"
-                ] = f"{net_interface['label_name']}:{','.join(payload_string_list)}"
+                payload["interfaces"] = (
+                    f"{net_interface['label_name']}:{','.join(payload_string_list)}"
+                )
                 break  # Right now, compose only allows for one network interface.
         if "storage" in payload:
             tmp = payload.pop("storage")

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -13,7 +13,6 @@ __metaclass__ = type
 
 
 class MaasValueMapper:
-
     """
     Represent abstract class.
     """


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed.

Change links pointing to MAAS org to use Canonical org.

## Checklist before merging
- [x] Formatting: `tox -e format`
- [x] Linting: `tox -e sanity`
- [x] Unit tests: `tox -e units`
