### PR TITLE
feat/maas-settings-module

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,7 +18,7 @@ jobs:
           env -C "$GITHUB_WORKSPACE/$REPO_DIR" -- tox -e docs
 
   sanity-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
           env -C "$GITHUB_WORKSPACE/$REPO_DIR" -- tox -e sanity
 
   units-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /tests/integration/inventory
 /docs/build
 /docs/source/modules/*.rst
+
+.ansible

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"

--- a/plugins/modules/maas_config.py
+++ b/plugins/modules/maas_config.py
@@ -14,14 +14,16 @@ module: maas_config
 author:
   - Patrick Pfurtscheller (@pfurtschellerp)
 short_description: Manage MAAS configuration parameters.
+description:
+  - This module allows you to manage MAAS configuration parameters by setting their values.
 version_added: 1.1.0
 extends_documentation_fragment:
   - maas.maas.cluster_instance
 seealso: []
 options:
   name:
-      description:
-        - Setting to be changed.
+    description:
+      - Setting to be changed.
     type: str
     required: True
   value:

--- a/plugins/modules/maas_config.py
+++ b/plugins/modules/maas_config.py
@@ -35,8 +35,8 @@ EXAMPLES = r"""
 - name: Set maas_name configuration parameter
   maas.maas.config:
     cluster_instance: my-cluster-instance
-    setting: maas_name
-    setting_value: new-maas-name
+    name: maas_name
+    value: new-maas-name
 """
 
 RETURN = r"""

--- a/plugins/modules/maas_config.py
+++ b/plugins/modules/maas_config.py
@@ -50,27 +50,29 @@ record:
     value: new-maas-name
 """
 
-import json
-
 from ansible.module_utils.basic import AnsibleModule
 
 from ..module_utils import arguments, errors
 from ..module_utils.client import Client
 from ..module_utils.cluster_instance import get_oauth1_client
 
-DEBUG = []
 
 def run(module, client: Client):
     name = module.params["name"]
     value = module.params["value"]
     changed = False
 
-    current_value = client.get("/api/2.0/maas/op-get_config", query={"name": name}).json
+    current_value = client.get(
+        "/api/2.0/maas/op-get_config", query={"name": name}
+    ).json
 
     if current_value != value:
         changed = True
         if not module.check_mode:
-          client.post("/api/2.0/maas/op-set_config", data={"name": name, "value": value})
+            client.post(
+                "/api/2.0/maas/op-set_config",
+                data={"name": name, "value": value},
+            )
 
     record = {"name": name, "value": value}
 

--- a/plugins/modules/maas_config.py
+++ b/plugins/modules/maas_config.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2026, Boehringer Ingelheim
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+module: maas_config
+
+author:
+  - Patrick Pfurtscheller (@pfurtschellerp)
+short_description: Manage MAAS configuration parameters.
+version_added: 1.1.0
+extends_documentation_fragment:
+  - maas.maas.cluster_instance
+seealso: []
+options:
+  name:
+      description:
+        - Setting to be changed.
+    type: str
+    required: True
+  value:
+    description:
+      - Desired value of the configuration parameter.
+    type: str
+    required: True
+"""
+
+EXAMPLES = r"""
+- name: Set maas_name configuration parameter
+  maas.maas.config:
+    cluster_instance: my-cluster-instance
+    setting: maas_name
+    setting_value: new-maas-name
+"""
+
+RETURN = r"""
+record:
+  description:
+    - Set configuration parameter.
+  returned: success
+  type: dict
+  sample:
+    name: maas_name
+    value: new-maas-name
+"""
+
+import json
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils import arguments, errors
+from ..module_utils.client import Client
+from ..module_utils.cluster_instance import get_oauth1_client
+
+DEBUG = []
+
+def run(module, client: Client):
+    name = module.params["name"]
+    value = module.params["value"]
+    changed = False
+
+    current_value = client.get("/api/2.0/maas/op-get_config", query={"name": name}).json
+
+    if current_value != value:
+        changed = True
+        if not module.check_mode:
+          client.post("/api/2.0/maas/op-set_config", data={"name": name, "value": value})
+
+    record = {"name": name, "value": value}
+
+    return (changed, record)
+
+
+def main():
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=dict(
+            arguments.get_spec("cluster_instance"),
+            name=dict(type="str", required=True),
+            value=dict(type="str", required=True),
+        ),
+    )
+
+    try:
+        client = get_oauth1_client(module.params)
+        changed, record = run(module, client)
+        module.exit_json(changed=changed, record=record)
+    except errors.MaasError as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/maas_config/main.yml
+++ b/tests/integration/targets/maas_config/main.yml
@@ -1,0 +1,33 @@
+---
+- environment:
+    MAAS_HOST: "{{ host }}"
+    MAAS_TOKEN_KEY: "{{ token_key }}"
+    MAAS_TOKEN_SECRET: "{{ token_secret }}"
+    MAAS_CUSTOMER_KEY: "{{ customer_key }}"
+
+  block:
+    - name: Set Name of MAAS
+      maas.maas.maas_config:
+        name: maas_name
+        value: new_name
+      register: name_change
+
+    - name: Assert
+      ansible.builtin.assert:
+        that:
+          - name_change.changed
+          - name_change.record.value == "name_change"
+
+    - name: Set Name of MAAS again
+      maas.maas.maas_config:
+        name: maas_name
+        value: new_name
+      register: name_change
+
+
+    - name: Assert
+      ansible.builtin.assert:
+        that:
+          - not name_change.changed
+          - name_change.record.value == "name_change"
+

--- a/tests/integration/targets/maas_config/main.yml
+++ b/tests/integration/targets/maas_config/main.yml
@@ -24,10 +24,8 @@
         value: new_name
       register: name_change
 
-
     - name: Assert
       ansible.builtin.assert:
         that:
           - not name_change.changed
           - name_change.record.value == "name_change"
-

--- a/tests/unit/plugins/conftest.py
+++ b/tests/unit/plugins/conftest.py
@@ -89,6 +89,7 @@ def run_main(mocker):
         )
         args["ANSIBLE_MODULE_ARGS"].update(params or {})
         mocker.patch.object(basic, "_ANSIBLE_ARGS", to_bytes(json.dumps(args)))
+        mocker.patch.object(basic, "_ANSIBLE_PROFILE", "legacy")
 
         # We can mock the run function because we enforce module structure in our
         # development guidelines.
@@ -117,6 +118,7 @@ def run_main_with_reboot(mocker):
         )
         args["ANSIBLE_MODULE_ARGS"].update(params or {})
         mocker.patch.object(basic, "_ANSIBLE_ARGS", to_bytes(json.dumps(args)))
+        mocker.patch.object(basic, "_ANSIBLE_PROFILE", "legacy")
 
         # We can mock the run function because we enforce module structure in our
         # development guidelines.
@@ -145,6 +147,7 @@ def run_main_info(mocker):
         )
         args["ANSIBLE_MODULE_ARGS"].update(params or {})
         mocker.patch.object(basic, "_ANSIBLE_ARGS", to_bytes(json.dumps(args)))
+        mocker.patch.object(basic, "_ANSIBLE_PROFILE", "legacy")
 
         # We can mock the run function because we enforce module structure in our
         # development guidelines.

--- a/tox.ini
+++ b/tox.ini
@@ -7,14 +7,14 @@ skipsdist = True
 
 [testenv]
 deps =
-    ansible-core==2.14.5
-    pytest==7.1.2
-    pytest-mock==3.8.2
+    ansible-core==2.20.2
+    pytest==9.0.2
+    pytest-mock==3.15.1
 
 [testenv:coverage]
 deps =
     {[testenv]deps}
-    coverage==6.5.0
+    coverage==7.13.4
 commands =
     -ansible-test coverage erase  # On first run, there is nothing to erase.
     ansible-test units --venv --coverage
@@ -23,7 +23,7 @@ commands =
 
 [testenv:docs]
 deps =
-    ansible-core==2.14.5
+    ansible-core==2.20.2
     Sphinx
     sphinx-rtd-theme
     ansible-doc-extractor
@@ -84,7 +84,8 @@ commands =
 passenv =
   HOME
 deps =
-    ansible-lint==6.22.1
+    ansible-core==2.20.2
+    ansible-lint==26.1.1
     black
     flake8
     flake8-pyproject

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ commands =
     ansible-doc-extractor --template docs/templates/module.rst.j2 docs/source/modules plugins/modules/fabric.py
     ansible-doc-extractor --template docs/templates/module.rst.j2 docs/source/modules plugins/modules/fabric_info.py
     ansible-doc-extractor --template docs/templates/module.rst.j2 docs/source/modules plugins/modules/instance.py
+    ansible-doc-extractor --template docs/templates/module.rst.j2 docs/source/modules plugins/modules/maas_config.py
     ansible-doc-extractor --template docs/templates/module.rst.j2 docs/source/modules plugins/modules/machine.py
     ansible-doc-extractor --template docs/templates/module.rst.j2 docs/source/modules plugins/modules/machine_info.py
     ansible-doc-extractor --template docs/templates/module.rst.j2 docs/source/modules plugins/modules/network_interface_info.py


### PR DESCRIPTION
Adding a module to define individual settings for the maas itself.


## Checklist before merging
- [x] Formatting: `tox -e format`
- [x] Linting: `tox -e sanity` -> had to update Ansible version to run on python 3.14
- [x] Unit tests: `tox -e units`
